### PR TITLE
gl_b1300: Add English, Spanish, and French for UI

### DIFF
--- a/gl_b1300.diffconfig
+++ b/gl_b1300.diffconfig
@@ -9,3 +9,6 @@ CONFIG_PACKAGE_wpad-mesh=y
 CONFIG_PACKAGE_batctl-full=y
 CONFIG_PACKAGE_wpa-supplicant-wolfssl=y
 CONFIG_PACKAGE_wpad-mesh-openssl=y
+CONFIG_LUCI_LANG_en=y
+CONFIG_LUCI_LANG_es=y
+CONFIG_LUCI_LANG_fr=y


### PR DESCRIPTION
Adding these packages to the base image allows the UI to
automatically use these languages if the user's browser
is set to use them.  It also allows the user to select these
languages specifically (regardless of browser settings) in the
UI via System->System->Language and Style.

MIN-8357